### PR TITLE
[Fix/144] prevent duplicate game start on concurrent loading ack

### DIFF
--- a/docs/problem-solve/멀티_로딩ACK_동시완료_데드락_해결_보고서.md
+++ b/docs/problem-solve/멀티_로딩ACK_동시완료_데드락_해결_보고서.md
@@ -1,0 +1,157 @@
+# 멀티 로딩 ACK 동시 완료 데드락 해결 보고서
+
+## 1. 원인
+
+- `GameTransitionOrchestrator.handleLoadingAck(...)`는 각 ACK 요청을 독립 처리하고, `allArrived=true`이면 즉시 `onAllPlayersArrived(...)`를 실행한다.
+- 기존 구조에는 "한 게임 시작을 단 1회만 허용"하는 단일 승자 게이트가 없다.
+- 따라서 동시 ACK 상황에서 동일 `gameId`로 `nextRoadViewRoundUseCase.executeInitial(...)`가 중복 호출될 수 있다.
+- 초기 라운드 준비 트랜잭션이 중복 실행되면 `multi_road_view_game` 및 연관 라운드 생성 구간에서 락 경합이 커지고, InnoDB 데드락/락 획득 실패로 이어질 수 있다.
+
+## 2. 원인 분석
+
+### 2.1 호출 경로와 레이스 포인트
+
+- WebSocket 진입: `MultiGameWebSocketController.handleLoadingAck(...)`
+- 오케스트레이션: `GameTransitionOrchestrator.handleLoadingAck(...)`
+  - Redis ready 기록
+  - 로딩 상태 계산/브로드캐스트
+  - `allArrived`면 `onAllPlayersArrived(...)` 진입
+- 시작 처리: `onAllPlayersArrived(...)` -> `executeInitial(...)`
+
+### 2.2 실제 발생 가능성
+
+결론: **실제로 발생 가능하다.**
+
+재현 흐름:
+
+1. A/B ACK가 거의 동시에 수신
+2. 두 요청 모두 ready 상태를 기록
+3. 두 요청 모두 `allArrived=true` 관측
+4. 두 요청 모두 `onAllPlayersArrived` 진입
+5. 두 요청 모두 `executeInitial` 중복 실행 시도
+6. 동일 게임 레코드 UPDATE 및 라운드 생성 경합 중 데드락 가능
+
+핵심은 ACK 동시성 그 자체가 아니라, **"게임 시작 트랜잭션 중복 실행"** 이다.
+
+### 2.3 구조적 취약점
+
+- `allArrived` 판단만 있고 idempotency 보장이 없다.
+- 시작 전 `cleanupLoadingState`가 먼저 수행되어 실패 시 복구 단서가 약해진다.
+- 멀티 인스턴스 환경에서는 JVM 로컬 락으로 문제를 막을 수 없다.
+
+## 3. 해결 방안 분석, 비교
+
+### 방안 A: JVM 로컬 락(`synchronized`)
+
+- 장점: 구현 단순
+- 단점: 멀티 인스턴스 무효
+- 결론: 부적합
+
+### 방안 B: DB 락 단독(비관적 락)
+
+- 장점: 정합성 강함
+- 단점: ACK 폭주 시 DB 락 대기/병목
+- 결론: 단독 적용 시 운영 부담
+
+### 방안 C: Redis 락 단독
+
+- 장점: 빠른 중복 차단, 분산 환경 적합
+- 단점: TTL/해제 정책만으로는 최종 DB 상태 보장에 약점
+- 결론: 단독 적용은 리스크 존재
+
+### 방안 D: Redis 단일 승자 + DB 조건부 전이(권장)
+
+- Redis에서 시작 토큰 선점(SET NX EX)
+- 선점 성공 요청만 시작 시도
+- DB에서 `PENDING -> IN_PROGRESS` 조건부 전이로 최종 1회 보장
+- 중복 요청은 no-op
+
+결론: **현업 관점 최적해**
+
+## 4. 해결 방안 적용
+
+### 4.1 적용 원칙
+
+- deadlock 재시도보다 먼저, 중복 시작 자체를 차단
+- "게임 시작 1회" 불변식 강제
+
+### 4.2 적용 내용
+
+1) `GameTransitionOrchestrator.onAllPlayersArrived(...)`
+
+- `currentGameId` 조회 후 Redis game-start lock 획득 시도
+- 락 선점 실패 시 즉시 중복 요청 skip
+- `cleanupLoadingState`를 `executeInitial` 이후로 이동
+
+2) `RoundPreparationService.prepareInitialRound(...)`
+
+- 기존 `game.startGame()` 직접 호출 제거
+- `transitionToInProgressIfPending(gameId)` 성공 시에만 초기 라운드 생성
+- 실패 시 이미 시작/비정상 상태로 간주하고 null(no-op) 반환
+
+3) `MultiRoadViewGameRepository`
+
+- 조건부 update 쿼리 추가
+  - `status = PENDING`일 때만 `IN_PROGRESS`로 전이
+  - `currentRound = 1`, `isFinished = false` 동시 반영
+
+4) Redis 서비스 확장
+
+- 키: `game:room:{roomId}:game:{gameId}:start:lock`
+- TTL 30초
+- acquire/release 메서드 추가
+
+### 4.3 실제 반영 파일
+
+- `src/main/java/com/kospot/application/multi/flow/GameTransitionOrchestrator.java`
+- `src/main/java/com/kospot/application/multi/flow/LoadingPhaseService.java`
+- `src/main/java/com/kospot/infrastructure/redis/domain/multi/game/service/MultiGameRedisService.java`
+- `src/main/java/com/kospot/domain/multi/game/repository/MultiRoadViewGameRepository.java`
+- `src/main/java/com/kospot/domain/multi/game/adaptor/MultiRoadViewGameAdaptor.java`
+- `src/main/java/com/kospot/application/multi/round/roadview/RoundPreparationService.java`
+
+### 4.4 기대 효과
+
+- 동시 ACK N건에서도 시작 트랜잭션 1건만 유효 실행
+- `multi_road_view_game` 업데이트 경합 급감
+- 데드락 트리거(중복 시작) 구조적 제거
+
+## 5. 테스트 내용
+
+### 5.1 단위 테스트 설계
+
+- `onAllPlayersArrived`:
+  - 락 선점 성공 1건만 시작 호출
+  - 락 선점 실패 요청은 no-op
+- `RoundPreparationService.prepareInitialRound`:
+  - 조건부 전이 실패 시 null 반환
+  - 조건부 전이 성공 시 초기 라운드 생성
+
+### 5.2 통합 테스트 설계(동시성)
+
+- 동일 room/game로 ACK 20~100건 동시 주입
+- 검증 항목:
+  - `executeInitial` 실행 횟수 = 1
+  - `MultiRoadViewGame.status = IN_PROGRESS`
+  - 초기 라운드 생성 수 1건
+  - deadlock/lock-wait 예외 0건
+
+### 5.3 경계/장애 테스트 설계
+
+- 락 선점 후 프로세스 장애 시 TTL 만료 후 재진입 가능 여부
+- timeout 경로와 all-arrived 경로 경쟁 시 상호 모순 상태 미발생 검증
+- 멀티 인스턴스 환경 반복 검증
+
+### 5.4 이번 작업에서의 실행 결과
+
+- 추가 테스트 파일: `src/test/java/com/kospot/application/multi/round/roadview/RoundPreparationServiceTest.java`
+- 실행 시도: `./gradlew test --tests "com.kospot.application.multi.round.roadview.NextRoadViewRoundUseCaseTest"`
+- 결과: `worker.org.gradle.process.internal.worker.GradleWorkerMain` 로딩 실패로 `:compileJava` 단계 중단
+- 해석: 테스트 코드 검증 이전에 현재 환경의 Gradle worker 런타임 이슈 선해결 필요
+
+---
+
+### 최종 제안
+
+본 이슈는 **Redis 단일 승자 게이트 + DB 조건부 상태 전이**의 2중 방어가 가장 합리적이다.
+이 접근은 deadlock을 사후 재시도로 덮지 않고, 원인인 중복 시작 트랜잭션 자체를 차단한다.

--- a/src/main/java/com/kospot/application/multi/flow/GameTransitionOrchestrator.java
+++ b/src/main/java/com/kospot/application/multi/flow/GameTransitionOrchestrator.java
@@ -71,15 +71,14 @@ public class GameTransitionOrchestrator {
         loadingPhaseService.broadcastLoadingStatus(roomId, statusMessage);
 
         if (statusMessage.isAllArrived()) {
-            onAllPlayersArrived(roomId, message.getRoundId());
+            onAllPlayersArrived(roomId);
         }
     }
 
     /**
      * 모든 플레이어가 도착했을 때 게임을 시작한다.
      */
-    private void onAllPlayersArrived(String roomId, Long roundId) {
-        multiGameFlowScheduler.cancel(roomId, MultiGameFlowScheduler.FlowTaskType.LOADING_TIMEOUT);
+    private void onAllPlayersArrived(String roomId) {
         Long currentGameId = loadingPhaseService.getCurrentGameId(roomId);
 
         if (currentGameId == null) {
@@ -87,15 +86,32 @@ public class GameTransitionOrchestrator {
             return;
         }
 
+        boolean startLockAcquired = loadingPhaseService.acquireGameStartLock(roomId, currentGameId);
+        if (!startLockAcquired) {
+            log.info("Skip duplicate game start request - RoomId: {}, GameId: {}", roomId, currentGameId);
+            return;
+        }
+
+        boolean keepLockUntilTtl = false;
+
+        multiGameFlowScheduler.cancel(roomId, MultiGameFlowScheduler.FlowTaskType.LOADING_TIMEOUT);
         log.info("All players arrived. Starting game - RoomId: {}, GameId: {}", roomId, currentGameId);
-        loadingPhaseService.cleanupLoadingState(roomId);
 
         try {
             Long numericRoomId = Long.parseLong(roomId);
             nextRoadViewRoundUseCase.executeInitial(numericRoomId, currentGameId);
+            loadingPhaseService.cleanupLoadingState(roomId);
+            keepLockUntilTtl = true;
         } catch (NumberFormatException e) {
             log.error("Failed to parse room id for starting game - RoomId: {}, GameId: {}",
                     roomId, currentGameId, e);
+        } catch (RuntimeException e) {
+            log.error("Failed to execute initial round - RoomId: {}, GameId: {}", roomId, currentGameId, e);
+            throw e;
+        } finally {
+            if (!keepLockUntilTtl) {
+                loadingPhaseService.releaseGameStartLock(roomId, currentGameId);
+            }
         }
     }
 

--- a/src/main/java/com/kospot/application/multi/flow/LoadingPhaseService.java
+++ b/src/main/java/com/kospot/application/multi/flow/LoadingPhaseService.java
@@ -101,6 +101,14 @@ public class LoadingPhaseService {
         return multiGameRedisService.getCurrentGameId(roomId);
     }
 
+    public boolean acquireGameStartLock(String roomId, Long gameId) {
+        return multiGameRedisService.acquireGameStartLock(roomId, gameId);
+    }
+
+    public void releaseGameStartLock(String roomId, Long gameId) {
+        multiGameRedisService.releaseGameStartLock(roomId, gameId);
+    }
+
     /**
      * 로딩 상태를 정리한다.
      *

--- a/src/main/java/com/kospot/application/multi/round/roadview/RoundPreparationService.java
+++ b/src/main/java/com/kospot/application/multi/round/roadview/RoundPreparationService.java
@@ -40,14 +40,13 @@ public class RoundPreparationService {
      * @return 라운드 준비 결과 (게임이 이미 진행 중이면 null)
      */
     public InitialRoundResult prepareInitialRound(Long gameId) {
-        MultiRoadViewGame game = multiRoadViewGameAdaptor.queryById(gameId);
-
-        if (game.isInProgress()) {
-            log.info("Game already started - skip initial preparation. GameId: {}", gameId);
+        boolean transitioned = multiRoadViewGameAdaptor.transitionToInProgressIfPending(gameId);
+        if (!transitioned) {
+            log.info("Game already started or not pending - skip initial preparation. GameId: {}", gameId);
             return null;
         }
 
-        game.startGame();
+        MultiRoadViewGame game = multiRoadViewGameAdaptor.queryById(gameId);
 
         List<GamePlayer> players = gamePlayerAdaptor.queryByMultiRoadViewGameIdWithMember(gameId);
         List<Long> playerIds = players.stream()

--- a/src/main/java/com/kospot/domain/multi/game/adaptor/MultiRoadViewGameAdaptor.java
+++ b/src/main/java/com/kospot/domain/multi/game/adaptor/MultiRoadViewGameAdaptor.java
@@ -2,6 +2,7 @@ package com.kospot.domain.multi.game.adaptor;
 
 import com.kospot.domain.multi.game.entity.MultiRoadViewGame;
 import com.kospot.domain.multi.game.repository.MultiRoadViewGameRepository;
+import com.kospot.domain.multi.game.vo.MultiGameStatus;
 import com.kospot.infrastructure.exception.object.domain.GameHandler;
 import com.kospot.infrastructure.exception.payload.code.ErrorStatus;
 import com.kospot.infrastructure.annotation.adaptor.Adaptor;
@@ -25,6 +26,15 @@ public class MultiRoadViewGameAdaptor {
 
     public java.util.Optional<MultiRoadViewGame> findInProgressByGameRoomId(Long gameRoomId) {
         return repository.findInProgressByGameRoomId(gameRoomId);
+    }
+
+    @Transactional
+    public boolean transitionToInProgressIfPending(Long gameId) {
+        return repository.transitionToInProgressIfPending(
+                gameId,
+                MultiGameStatus.PENDING,
+                MultiGameStatus.IN_PROGRESS
+        ) == 1;
     }
 
 }

--- a/src/main/java/com/kospot/domain/multi/game/repository/MultiRoadViewGameRepository.java
+++ b/src/main/java/com/kospot/domain/multi/game/repository/MultiRoadViewGameRepository.java
@@ -1,7 +1,9 @@
 package com.kospot.domain.multi.game.repository;
 
 import com.kospot.domain.multi.game.entity.MultiRoadViewGame;
+import com.kospot.domain.multi.game.vo.MultiGameStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,5 +16,13 @@ public interface MultiRoadViewGameRepository extends JpaRepository<MultiRoadView
 
     @Query("SELECT g FROM MultiRoadViewGame g WHERE g.gameRoomId = :gameRoomId AND g.status = 'IN_PROGRESS'")
     Optional<MultiRoadViewGame> findInProgressByGameRoomId(@Param("gameRoomId") Long gameRoomId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE MultiRoadViewGame g " +
+            "SET g.status = :nextStatus, g.currentRound = 1, g.isFinished = false " +
+            "WHERE g.id = :gameId AND g.status = :expectedStatus")
+    int transitionToInProgressIfPending(@Param("gameId") Long gameId,
+                                        @Param("expectedStatus") MultiGameStatus expectedStatus,
+                                        @Param("nextStatus") MultiGameStatus nextStatus);
 
 }

--- a/src/main/java/com/kospot/infrastructure/redis/domain/multi/game/service/MultiGameRedisService.java
+++ b/src/main/java/com/kospot/infrastructure/redis/domain/multi/game/service/MultiGameRedisService.java
@@ -19,7 +19,9 @@ public class MultiGameRedisService {
     private static final int GAME_DATA_EXPIRY_HOURS = 1;
     private static final String ROUND_REISSUE_LOCK_KEY = "game:round:%s:%s:reissue:lock";
     private static final String ROUND_VERSION_KEY = "game:round:%s:%s:version";
+    private static final String GAME_START_LOCK_KEY = "game:room:%s:game:%s:start:lock";
     private static final long REISSUE_LOCK_TTL_SECONDS = 5L;
+    private static final long GAME_START_LOCK_TTL_SECONDS = 30L;
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -130,6 +132,17 @@ public class MultiGameRedisService {
         }
     }
 
+    public boolean acquireGameStartLock(String roomId, Long gameId) {
+        String key = getGameStartLockKey(roomId, gameId);
+        Boolean locked = redisTemplate.opsForValue()
+                .setIfAbsent(key, String.valueOf(System.currentTimeMillis()), GAME_START_LOCK_TTL_SECONDS, TimeUnit.SECONDS);
+        return Boolean.TRUE.equals(locked);
+    }
+
+    public void releaseGameStartLock(String roomId, Long gameId) {
+        redisTemplate.delete(getGameStartLockKey(roomId, gameId));
+    }
+
     private String getLoadingStatusKey(String roomId) {
         return String.format(GAME_LOADING_STATUS_KEY, roomId);
     }
@@ -144,6 +157,10 @@ public class MultiGameRedisService {
 
     private String getRoundVersionKey(String roomId, Long roundId) {
         return String.format(ROUND_VERSION_KEY, roomId, roundId);
+    }
+
+    private String getGameStartLockKey(String roomId, Long gameId) {
+        return String.format(GAME_START_LOCK_KEY, roomId, gameId);
     }
 }
 

--- a/src/test/java/com/kospot/application/multi/flow/GameTransitionOrchestratorConcurrencyTest.java
+++ b/src/test/java/com/kospot/application/multi/flow/GameTransitionOrchestratorConcurrencyTest.java
@@ -1,0 +1,111 @@
+package com.kospot.application.multi.flow;
+
+import com.kospot.application.multi.game.message.LoadingStatusMessage;
+import com.kospot.application.multi.round.roadview.NextRoadViewRoundUseCase;
+import com.kospot.domain.multi.game.adaptor.MultiRoadViewGameAdaptor;
+import com.kospot.infrastructure.websocket.auth.WebSocketMemberPrincipal;
+import com.kospot.presentation.multi.game.dto.message.LoadingAckMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GameTransitionOrchestratorConcurrencyTest {
+
+    private static final String ROOM_ID = "1";
+    private static final Long GAME_ID = 2L;
+
+    @Mock
+    private LoadingPhaseService loadingPhaseService;
+
+    @Mock
+    private MultiGameFlowScheduler multiGameFlowScheduler;
+
+    @Mock
+    private NextRoadViewRoundUseCase nextRoadViewRoundUseCase;
+
+    @Mock
+    private MultiRoadViewGameAdaptor multiRoadViewGameAdaptor;
+
+    @InjectMocks
+    private GameTransitionOrchestrator orchestrator;
+
+    @Test
+    void handleLoadingAck_startsOnlyOnce_whenTwoAcksArriveConcurrently() throws Exception {
+        LoadingStatusMessage allArrived = LoadingStatusMessage.builder()
+                .players(java.util.List.of())
+                .allArrived(true)
+                .build();
+
+        when(loadingPhaseService.buildLoadingStatusMessage(ROOM_ID)).thenReturn(allArrived);
+        when(loadingPhaseService.getCurrentGameId(ROOM_ID)).thenReturn(GAME_ID);
+
+        AtomicBoolean winner = new AtomicBoolean(false);
+        when(loadingPhaseService.acquireGameStartLock(ROOM_ID, GAME_ID))
+                .thenAnswer(invocation -> winner.compareAndSet(false, true));
+
+        CountDownLatch bothReachedMarkReady = new CountDownLatch(2);
+        CountDownLatch releaseMarkReady = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            bothReachedMarkReady.countDown();
+            boolean released = releaseMarkReady.await(2, TimeUnit.SECONDS);
+            assertThat(released).isTrue();
+            return null;
+        }).when(loadingPhaseService).markPlayerReady(eq(ROOM_ID), anyLong(), anyLong(), anyLong());
+
+        LoadingAckMessage message = new LoadingAckMessage();
+        message.setRoundId(0L);
+        message.setClientTimestamp(System.currentTimeMillis());
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> first = executor.submit(() -> orchestrator.handleLoadingAck(
+                    ROOM_ID, message, headerAccessor(101L)));
+            Future<?> second = executor.submit(() -> orchestrator.handleLoadingAck(
+                    ROOM_ID, message, headerAccessor(102L)));
+
+            boolean bothWaiting = bothReachedMarkReady.await(2, TimeUnit.SECONDS);
+            assertThat(bothWaiting).isTrue();
+            releaseMarkReady.countDown();
+
+            first.get(2, TimeUnit.SECONDS);
+            second.get(2, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        verify(loadingPhaseService, times(2)).acquireGameStartLock(ROOM_ID, GAME_ID);
+        verify(nextRoadViewRoundUseCase, times(1)).executeInitial(1L, GAME_ID);
+        verify(loadingPhaseService, times(1)).cleanupLoadingState(ROOM_ID);
+        verify(multiGameFlowScheduler, times(1))
+                .cancel(ROOM_ID, MultiGameFlowScheduler.FlowTaskType.LOADING_TIMEOUT);
+    }
+
+    private SimpMessageHeaderAccessor headerAccessor(Long memberId) {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        HashMap<String, Object> sessionAttributes = new HashMap<>();
+        sessionAttributes.put("user", new WebSocketMemberPrincipal(memberId, "nick", "n@k.com", "USER"));
+        accessor.setSessionAttributes(sessionAttributes);
+        return accessor;
+    }
+}

--- a/src/test/java/com/kospot/application/multi/round/roadview/RoundPreparationServiceTest.java
+++ b/src/test/java/com/kospot/application/multi/round/roadview/RoundPreparationServiceTest.java
@@ -1,0 +1,79 @@
+package com.kospot.application.multi.round.roadview;
+
+import com.kospot.domain.multi.game.adaptor.MultiRoadViewGameAdaptor;
+import com.kospot.domain.multi.game.entity.MultiRoadViewGame;
+import com.kospot.domain.multi.gamePlayer.adaptor.GamePlayerAdaptor;
+import com.kospot.domain.multi.gamePlayer.entity.GamePlayer;
+import com.kospot.domain.multi.round.adaptor.RoadViewGameRoundAdaptor;
+import com.kospot.domain.multi.round.entity.RoadViewGameRound;
+import com.kospot.domain.multi.round.service.roadview.RoadViewGameRoundService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoundPreparationServiceTest {
+
+    private static final Long GAME_ID = 10L;
+
+    @Mock
+    private MultiRoadViewGameAdaptor multiRoadViewGameAdaptor;
+
+    @Mock
+    private RoadViewGameRoundAdaptor roadViewGameRoundAdaptor;
+
+    @Mock
+    private RoadViewGameRoundService roadViewGameRoundService;
+
+    @Mock
+    private GamePlayerAdaptor gamePlayerAdaptor;
+
+    @InjectMocks
+    private RoundPreparationService roundPreparationService;
+
+    @Test
+    void prepareInitialRound_returnsNull_whenGameAlreadyStartedOrNotPending() {
+        when(multiRoadViewGameAdaptor.transitionToInProgressIfPending(GAME_ID)).thenReturn(false);
+
+        RoundPreparationService.InitialRoundResult result = roundPreparationService.prepareInitialRound(GAME_ID);
+
+        assertThat(result).isNull();
+        verify(multiRoadViewGameAdaptor, never()).queryById(GAME_ID);
+        verifyNoInteractions(roadViewGameRoundService);
+    }
+
+    @Test
+    void prepareInitialRound_createsFirstRound_whenTransitionSucceeded() {
+        MultiRoadViewGame game = mock(MultiRoadViewGame.class);
+        GamePlayer player1 = mock(GamePlayer.class);
+        GamePlayer player2 = mock(GamePlayer.class);
+        RoadViewGameRound round = mock(RoadViewGameRound.class);
+
+        when(multiRoadViewGameAdaptor.transitionToInProgressIfPending(GAME_ID)).thenReturn(true);
+        when(multiRoadViewGameAdaptor.queryById(GAME_ID)).thenReturn(game);
+        when(gamePlayerAdaptor.queryByMultiRoadViewGameIdWithMember(GAME_ID)).thenReturn(List.of(player1, player2));
+        when(player1.getId()).thenReturn(1L);
+        when(player2.getId()).thenReturn(2L);
+        when(roadViewGameRoundService.createGameRound(game, List.of(1L, 2L))).thenReturn(round);
+
+        RoundPreparationService.InitialRoundResult result = roundPreparationService.prepareInitialRound(GAME_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getGame()).isSameAs(game);
+        assertThat(result.getRound()).isSameAs(round);
+        assertThat(result.getPlayers()).containsExactly(player1, player2);
+        verify(multiRoadViewGameAdaptor).queryById(GAME_ID);
+        verify(roadViewGameRoundService).createGameRound(game, List.of(1L, 2L));
+    }
+}


### PR DESCRIPTION
Add redis single-winner start lock and DB conditional status transition to keep initial round start idempotent under concurrent ACKs. Add concurrency-focused unit tests and update the incident report with applied mitigation and validation plan.

# 멀티 로딩 ACK 동시 완료 데드락 해결 보고서

## 1. 원인

- `GameTransitionOrchestrator.handleLoadingAck(...)`는 각 ACK 요청을 독립 처리하고, `allArrived=true`이면 즉시 `onAllPlayersArrived(...)`를 실행한다.
- 기존 구조에는 "한 게임 시작을 단 1회만 허용"하는 단일 승자 게이트가 없다.
- 따라서 동시 ACK 상황에서 동일 `gameId`로 `nextRoadViewRoundUseCase.executeInitial(...)`가 중복 호출될 수 있다.
- 초기 라운드 준비 트랜잭션이 중복 실행되면 `multi_road_view_game` 및 연관 라운드 생성 구간에서 락 경합이 커지고, InnoDB 데드락/락 획득 실패로 이어질 수 있다.

## 2. 원인 분석

### 2.1 호출 경로와 레이스 포인트

- WebSocket 진입: `MultiGameWebSocketController.handleLoadingAck(...)`
- 오케스트레이션: `GameTransitionOrchestrator.handleLoadingAck(...)`
  - Redis ready 기록
  - 로딩 상태 계산/브로드캐스트
  - `allArrived`면 `onAllPlayersArrived(...)` 진입
- 시작 처리: `onAllPlayersArrived(...)` -> `executeInitial(...)`

### 2.2 실제 발생 가능성

결론: **실제로 발생 가능하다.**

재현 흐름:

1. A/B ACK가 거의 동시에 수신
2. 두 요청 모두 ready 상태를 기록
3. 두 요청 모두 `allArrived=true` 관측
4. 두 요청 모두 `onAllPlayersArrived` 진입
5. 두 요청 모두 `executeInitial` 중복 실행 시도
6. 동일 게임 레코드 UPDATE 및 라운드 생성 경합 중 데드락 가능

핵심은 ACK 동시성 그 자체가 아니라, **"게임 시작 트랜잭션 중복 실행"** 이다.

### 2.3 구조적 취약점

- `allArrived` 판단만 있고 idempotency 보장이 없다.
- 시작 전 `cleanupLoadingState`가 먼저 수행되어 실패 시 복구 단서가 약해진다.
- 멀티 인스턴스 환경에서는 JVM 로컬 락으로 문제를 막을 수 없다.

## 3. 해결 방안 분석, 비교

### 방안 A: JVM 로컬 락(`synchronized`)

- 장점: 구현 단순
- 단점: 멀티 인스턴스 무효
- 결론: 부적합

### 방안 B: DB 락 단독(비관적 락)

- 장점: 정합성 강함
- 단점: ACK 폭주 시 DB 락 대기/병목
- 결론: 단독 적용 시 운영 부담

### 방안 C: Redis 락 단독

- 장점: 빠른 중복 차단, 분산 환경 적합
- 단점: TTL/해제 정책만으로는 최종 DB 상태 보장에 약점
- 결론: 단독 적용은 리스크 존재

### 방안 D: Redis 단일 승자 + DB 조건부 전이(권장)

- Redis에서 시작 토큰 선점(SET NX EX)
- 선점 성공 요청만 시작 시도
- DB에서 `PENDING -> IN_PROGRESS` 조건부 전이로 최종 1회 보장
- 중복 요청은 no-op

결론: **현업 관점 최적해**

## 4. 해결 방안 적용

### 4.1 적용 원칙

- deadlock 재시도보다 먼저, 중복 시작 자체를 차단
- "게임 시작 1회" 불변식 강제

### 4.2 적용 내용

1) `GameTransitionOrchestrator.onAllPlayersArrived(...)`

- `currentGameId` 조회 후 Redis game-start lock 획득 시도
- 락 선점 실패 시 즉시 중복 요청 skip
- `cleanupLoadingState`를 `executeInitial` 이후로 이동

2) `RoundPreparationService.prepareInitialRound(...)`

- 기존 `game.startGame()` 직접 호출 제거
- `transitionToInProgressIfPending(gameId)` 성공 시에만 초기 라운드 생성
- 실패 시 이미 시작/비정상 상태로 간주하고 null(no-op) 반환

3) `MultiRoadViewGameRepository`

- 조건부 update 쿼리 추가
  - `status = PENDING`일 때만 `IN_PROGRESS`로 전이
  - `currentRound = 1`, `isFinished = false` 동시 반영

4) Redis 서비스 확장

- 키: `game:room:{roomId}:game:{gameId}:start:lock`
- TTL 30초
- acquire/release 메서드 추가

### 4.3 실제 반영 파일

- `src/main/java/com/kospot/application/multi/flow/GameTransitionOrchestrator.java`
- `src/main/java/com/kospot/application/multi/flow/LoadingPhaseService.java`
- `src/main/java/com/kospot/infrastructure/redis/domain/multi/game/service/MultiGameRedisService.java`
- `src/main/java/com/kospot/domain/multi/game/repository/MultiRoadViewGameRepository.java`
- `src/main/java/com/kospot/domain/multi/game/adaptor/MultiRoadViewGameAdaptor.java`
- `src/main/java/com/kospot/application/multi/round/roadview/RoundPreparationService.java`

### 4.4 기대 효과

- 동시 ACK N건에서도 시작 트랜잭션 1건만 유효 실행
- `multi_road_view_game` 업데이트 경합 급감
- 데드락 트리거(중복 시작) 구조적 제거

## 5. 테스트 내용

### 5.1 단위 테스트 설계

- `onAllPlayersArrived`:
  - 락 선점 성공 1건만 시작 호출
  - 락 선점 실패 요청은 no-op
- `RoundPreparationService.prepareInitialRound`:
  - 조건부 전이 실패 시 null 반환
  - 조건부 전이 성공 시 초기 라운드 생성

### 5.2 통합 테스트 설계(동시성)

- 동일 room/game로 ACK 20~100건 동시 주입
- 검증 항목:
  - `executeInitial` 실행 횟수 = 1
  - `MultiRoadViewGame.status = IN_PROGRESS`
  - 초기 라운드 생성 수 1건
  - deadlock/lock-wait 예외 0건

### 5.3 경계/장애 테스트 설계

- 락 선점 후 프로세스 장애 시 TTL 만료 후 재진입 가능 여부
- timeout 경로와 all-arrived 경로 경쟁 시 상호 모순 상태 미발생 검증
- 멀티 인스턴스 환경 반복 검증

### 5.4 이번 작업에서의 실행 결과

- 추가 테스트 파일: `src/test/java/com/kospot/application/multi/round/roadview/RoundPreparationServiceTest.java`
- 실행 시도: `./gradlew test --tests "com.kospot.application.multi.round.roadview.NextRoadViewRoundUseCaseTest"`
- 결과: `worker.org.gradle.process.internal.worker.GradleWorkerMain` 로딩 실패로 `:compileJava` 단계 중단
- 해석: 테스트 코드 검증 이전에 현재 환경의 Gradle worker 런타임 이슈 선해결 필요

---

### 최종 제안

본 이슈는 **Redis 단일 승자 게이트 + DB 조건부 상태 전이**의 2중 방어가 가장 합리적이다.
이 접근은 deadlock을 사후 재시도로 덮지 않고, 원인인 중복 시작 트랜잭션 자체를 차단한다.

closes #144 