### PR TITLE
[Fix/142] resolve SimpUserRegistry not saved

### DIFF
--- a/src/main/java/com/kospot/common/websocket/interceptor/WebSocketChannelInterceptor.java
+++ b/src/main/java/com/kospot/common/websocket/interceptor/WebSocketChannelInterceptor.java
@@ -17,6 +17,7 @@ import org.springframework.messaging.MessageChannel;
 
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.lang.NonNull;
 
@@ -46,7 +47,8 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
 
     @Override
     public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+//        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
         if (accessor.getCommand() != null) {
             switch (accessor.getCommand()) {
@@ -69,7 +71,6 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
      */
     private void handleConnect(StompHeaderAccessor accessor) {
         String token = extractTokenOrNull(accessor);
-
         WebSocketMemberPrincipal principal;
         if (token != null) {
             principal = createPrincipalFromToken(token);
@@ -123,7 +124,6 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
         String destination = accessor.getDestination();
         String sessionId = accessor.getSessionId();
         String subscriptionId = accessor.getSubscriptionId();
-
         if (destination == null) {
             throw new WebSocketHandler(ErrorStatus.INVALID_DESTINATION);
         }

--- a/src/main/java/com/kospot/common/websocket/subscription/impl/NotificationTopicSubscriptionValidator.java
+++ b/src/main/java/com/kospot/common/websocket/subscription/impl/NotificationTopicSubscriptionValidator.java
@@ -25,7 +25,8 @@ public class NotificationTopicSubscriptionValidator implements SubscriptionValid
         if (destination == null) {
             return false;
         }
-        return destination.startsWith(NotificationChannelConstants.PREFIX_NOTIFICATION);
+        return destination.startsWith(NotificationChannelConstants.PREFIX_NOTIFICATION)
+                || NotificationChannelConstants.PERSONAL_NOTIFICATION_SUBSCRIBE_CHANNEL.equals(destination);
     }
 
     @Override

--- a/src/main/java/com/kospot/member/application/usecase/SearchMembersByNicknameUseCase.java
+++ b/src/main/java/com/kospot/member/application/usecase/SearchMembersByNicknameUseCase.java
@@ -29,7 +29,7 @@ public class SearchMembersByNicknameUseCase {
     private final FriendPairService friendPairService;
 
     public List<SearchMemberResponse> execute(Long memberId, String nickname) {
-        Member member = memberAdaptor.queryById(memberId);
+        Member member = memberAdaptor.queryByIdFetchMarkerImage(memberId);
         List<Member> foundMember = memberAdaptor.queryAllByNicknameKeyword(nickname);
 
         if (foundMember.isEmpty()) {

--- a/src/main/java/com/kospot/notification/infrastructure/websocket/service/NotificationPushService.java
+++ b/src/main/java/com/kospot/notification/infrastructure/websocket/service/NotificationPushService.java
@@ -6,13 +6,22 @@ import com.kospot.notification.presentation.dto.message.NotificationMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.user.SimpSession;
+import org.springframework.messaging.simp.user.SimpSubscription;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationPushService {
 
+
+    private final SimpUserRegistry simpUserRegistry;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
     @WebSocketDoc(
@@ -32,6 +41,17 @@ public class NotificationPushService {
             destination = "/user/queue/notification"
     )
     public void sendToMember(Long memberId, NotificationMessage message) {
+        SimpUser user = simpUserRegistry.getUser(String.valueOf(memberId));
+        log.info("before send - username={}, userExists={}", memberId, user != null);
+        Set<SimpUser> users = simpUserRegistry.getUsers();
+        if (user != null) {
+            for (SimpSession session : user.getSessions()) {
+                log.info(" sessionId={}", session.getId());
+                for (SimpSubscription sub : session.getSubscriptions()) {
+                    log.info("  subId={}, dest={}", sub.getId(), sub.getDestination());
+                }
+            }
+        }
         simpMessagingTemplate.convertAndSendToUser(
                 String.valueOf(memberId),
                 NotificationChannelConstants.getPersonalNotificationSendDestination(),


### PR DESCRIPTION
# WebSocket SimpUserRegistry 미등록 트러블슈팅 보고서

---

## 개요

| 항목 | 내용 |
|------|------|
| 발생 일자 | 2026-03-09 |
| 대상 컴포넌트 | `WebSocketChannelInterceptor` |
| 심각도 | High |
| 상태 | ✅ 해결 완료 |

---

## 1. 문제 현상

- `SimpUserRegistry`에 WebSocket 접속 사용자가 등록되지 않음
- `/user/queue/...` 형태의 개인 채널로 서버 → 클라이언트 푸시 메시지가 silent하게 유실됨
- `simpMessagingTemplate.convertAndSendToUser(...)` 호출 시 대상 사용자를 찾지 못함
- SEND / SUBSCRIBE 등 개별 기능은 `sessionAttributes` 우회로 동작하여 문제가 잘 드러나지 않았음

---

## 2. 원인 분석

### 문제 코드

```java
@Override
public Message preSend(@NonNull Message message, @NonNull MessageChannel channel) {
    // ❌ wrap()은 원본 message를 감싸는 새 래퍼 인스턴스를 반환
    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);

    if (accessor.getCommand() != null) {
        switch (accessor.getCommand()) {
            case CONNECT -> handleConnect(accessor);
            // ...
        }
    }
    return message; // 원본 message 그대로 반환 → Principal 반영 안 됨
}

private void handleConnect(StompHeaderAccessor accessor) {
    // ...
    accessor.setUser(principal); // ❌ 래퍼에만 적용, 원본 message는 불변
}
```

### 근본 원인

`StompHeaderAccessor.wrap(message)`는 **원본 메시지를 감싸는 새로운 래퍼 인스턴스**를 생성한다.  
이 래퍼에서 `setUser()`를 호출해도 **원본 `Message<?>` 객체의 헤더에는 반영되지 않는다.**

`SimpUserRegistry`는 `preSend()`가 최종 반환한 `Message<?>` 객체에서 `Principal`을 읽기 때문에,  
원본 message가 변경되지 않으면 사용자 등록이 이루어지지 않는다.

### 내부 동작 흐름

```
ChannelInterceptor.preSend()
    └─ StompHeaderAccessor.wrap(message)   → 새 래퍼 인스턴스 (원본과 분리)
        └─ accessor.setUser(principal)     → 래퍼에만 적용
            └─ return message              → 원본 message 반환 (Principal = null)
                └─ SimpUserRegistry        → Principal 읽음 → null → 미등록
```

### `wrap()` vs `getAccessor()` 비교

| 구분 | `StompHeaderAccessor.wrap(message)` | `MessageHeaderAccessor.getAccessor(message, ...)` |
|------|--------------------------------------|---------------------------------------------------|
| 반환 객체 | 새 래퍼 인스턴스 (원본과 분리) | 원본 메시지에 붙은 accessor (동일 참조) |
| `setUser()` 효과 | 래퍼에만 적용, 원본 불변 | 원본 메시지 헤더에 직접 반영 |
| SimpUserRegistry 등록 | ❌ 미등록 | ✅ 정상 등록 |

---

## 3. 영향 범위

`sessionAttributes`에 `user`를 저장하는 우회 로직 덕분에 아래 기능은 정상 동작했으나,  
`SimpUserRegistry` 의존 기능은 전부 영향을 받았다.

| 기능 | 영향 |
|------|------|
| `convertAndSendToUser(username, ...)` | ❌ 사용자 찾지 못해 메시지 유실 |
| `/user/queue/...` 개인 채널 구독 라우팅 | ❌ silent 실패 |
| `simpUserRegistry.getUser(username)` | ❌ null 반환 |
| SEND / SUBSCRIBE 처리 | ✅ sessionAttributes 우회로 정상 동작 |
| Rate Limiting | ✅ 정상 동작 |

---

## 4. 해결 방법

`StompHeaderAccessor.wrap()` 대신 `MessageHeaderAccessor.getAccessor()`를 사용하여  
원본 메시지의 헤더를 직접 수정할 수 있는 mutable accessor를 얻는다.

### 수정 코드

```java
@Override
public Message preSend(@NonNull Message message, @NonNull MessageChannel channel) {
    // ✅ getAccessor()로 원본 메시지에 연결된 accessor를 직접 가져옴
    StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(
        message, StompHeaderAccessor.class
    );

    if (accessor != null && accessor.getCommand() != null) {
        switch (accessor.getCommand()) {
            case CONNECT -> handleConnect(accessor);
            case SEND -> handleSend(accessor);
            case SUBSCRIBE -> handleSubscribe(accessor);
            case DISCONNECT -> handleDisconnect(accessor);
            case UNSUBSCRIBE -> handleUnsubscribe(accessor);
            default -> { }
        }
    }

    return message;
}
```

`handleConnect()` 내부의 `accessor.setUser(principal)` 호출은 그대로 유지하되,  
accessor가 원본 메시지를 직접 참조하므로 `setUser()` 결과가 `SimpUserRegistry`에 정상 반영된다.

---

## 5. 재발 방지

- WebSocket ChannelInterceptor 작성 시 **`StompHeaderAccessor.wrap()` 사용 금지** 원칙을 코드 컨벤션으로 등록
- `preSend()`에서 `Principal`을 설정하는 경우 반드시 `MessageHeaderAccessor.getAccessor()` 사용
- 개인 채널 푸시(`convertAndSendToUser`) 기능에 대한 통합 테스트 케이스 추가하여 회귀 방지

---## 📌 Summary  
<!-- PR의 목적과 변경 사항을 간략히 설명하세요. -->  

## ✨ Changes  
- ✅ Change 1  
- ✅ Change 2  
- ✅ Change 3  

## 🔍 How to Test  

1. ⬜ **Step 1:** 설명  
2. ⬜ **Step 2:** 설명  
3. ⬜ **Step 3:** 설명  

## ✅ Checklist  
- [ ] Code follows project coding style  
- [ ] Tests added/updated (if needed)  
- [ ] Documentation updated (if needed)  

## 🔗 Related Issues  
<!-- 관련된 이슈가 있다면 링크하세요. (예: Closes #123) -->  
Closes #  

## 💬 Comments  
<!-- 추가로 공유할 내용이 있다면 여기에 적으세요. -->  
